### PR TITLE
Create workflow for publishing package with a dev tag

### DIFF
--- a/.github/workflows/npm-publish-dev.yml
+++ b/.github/workflows/npm-publish-dev.yml
@@ -1,0 +1,21 @@
+name: Publish package to NPM with dev tag
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: yarn
+      - run: yarn build
+      - run: yarn publish --access=public --tag=dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
on push to `dev`  branch we need to publish package to npm with a `dev` tag to allow tool testing